### PR TITLE
ui: Exercise Library行のGIF拡大 + タグ簡素化

### DIFF
--- a/MuscleMap/Views/Components/ExerciseGifView.swift
+++ b/MuscleMap/Views/Components/ExerciseGifView.swift
@@ -7,7 +7,7 @@ enum ExerciseGifSize {
     case fullWidth     // ExerciseDetailView用（アニメーション、maxHeight: 300）
     case previewCard   // ExercisePreviewSheet用（アニメーション、height: 120）
     case card          // MuscleDetailView カード型リスト用（静止画、height: 160）
-    case thumbnail     // ExerciseLibraryView等のリスト行用（静止画、120x90）
+    case thumbnail     // ExerciseLibraryView等のリスト行用（静止画、100x75）
 
     var shouldAnimate: Bool {
         self == .fullWidth || self == .previewCard
@@ -73,7 +73,7 @@ struct ExerciseGifView: View {
                         .resizable()
                         .scaledToFit()
                         .padding(4)
-                        .frame(width: 80, height: 60)
+                        .frame(width: 100, height: 75)
                         .background(Color.white)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .overlay(
@@ -236,7 +236,7 @@ extension UIImage {
 
                 // Thumbnail size preview
                 VStack {
-                    Text("Thumbnail (80x60)")
+                    Text("Thumbnail (100x75)")
                         .font(.caption)
                         .foregroundStyle(Color.mmTextSecondary)
 

--- a/MuscleMap/Views/Components/MicroBodyMapView.swift
+++ b/MuscleMap/Views/Components/MicroBodyMapView.swift
@@ -1,0 +1,235 @@
+import SwiftUI
+
+// MARK: - カレンダー用マイクロボディマップ（前面+背面 2体表示）
+
+/// 6ゾーンの超簡略ボディシルエットを前後2体並べて表示
+/// カレンダーセル（約45x58pt）内に収まるサイズ設計
+struct MicroBodyMapView: View {
+    let muscleGroups: Set<MuscleGroup>
+
+    var body: some View {
+        HStack(spacing: 2) {
+            // 前面
+            SingleMicroBody(
+                muscleGroups: muscleGroups,
+                isFront: true
+            )
+            // 背面
+            SingleMicroBody(
+                muscleGroups: muscleGroups,
+                isFront: false
+            )
+        }
+    }
+}
+
+// MARK: - 単体マイクロボディ（前面 or 背面）
+
+private struct SingleMicroBody: View {
+    let muscleGroups: Set<MuscleGroup>
+    let isFront: Bool
+
+    // ゾーンごとの色判定
+    private func zoneColor(_ group: MuscleGroup) -> Color {
+        muscleGroups.contains(group)
+            ? muscleGroupColor(group)
+            : Color.mmTextSecondary.opacity(0.15)
+    }
+
+    // 胴体中央: 前面=chest, 背面=back
+    private var torsoColor: Color {
+        if isFront {
+            return zoneColor(.chest)
+        } else {
+            return zoneColor(.back)
+        }
+    }
+
+    var body: some View {
+        Canvas { context, size in
+            let w = size.width
+            let h = size.height
+
+            // --- レイアウト定義 ---
+            // 頭: 上部の小円
+            let headCenter = CGPoint(x: w * 0.5, y: h * 0.08)
+            let headRadius = w * 0.12
+
+            // 肩: 頭の下、左右に広い帯
+            let shoulderY = h * 0.17
+            let shoulderH = h * 0.08
+            let shoulderRect = CGRect(
+                x: w * 0.12, y: shoulderY,
+                width: w * 0.76, height: shoulderH
+            )
+
+            // 腕: 肩の外側、縦長
+            let armW = w * 0.14
+            let armH = h * 0.28
+            let armY = shoulderY + shoulderH * 0.2
+            let leftArmRect = CGRect(x: w * 0.02, y: armY, width: armW, height: armH)
+            let rightArmRect = CGRect(x: w - w * 0.02 - armW, y: armY, width: armW, height: armH)
+
+            // 胴体（胸 or 背中）: 肩の下、中央
+            let torsoY = shoulderY + shoulderH
+            let torsoH = h * 0.2
+            let torsoRect = CGRect(
+                x: w * 0.2, y: torsoY,
+                width: w * 0.6, height: torsoH
+            )
+
+            // 体幹（腹 or 腰）: 胴体の下
+            let coreY = torsoY + torsoH
+            let coreH = h * 0.14
+            let coreRect = CGRect(
+                x: w * 0.22, y: coreY,
+                width: w * 0.56, height: coreH
+            )
+
+            // 脚: 体幹の下、左右に分かれた2本
+            let legY = coreY + coreH + h * 0.01
+            let legH = h * 0.32
+            let legW = w * 0.22
+            let legGap = w * 0.04
+            let leftLegRect = CGRect(
+                x: w * 0.5 - legGap / 2 - legW, y: legY,
+                width: legW, height: legH
+            )
+            let rightLegRect = CGRect(
+                x: w * 0.5 + legGap / 2, y: legY,
+                width: legW, height: legH
+            )
+
+            // --- 描画 ---
+            // 頭（常にダークグレー）
+            let headPath = Path(ellipseIn: CGRect(
+                x: headCenter.x - headRadius,
+                y: headCenter.y - headRadius,
+                width: headRadius * 2,
+                height: headRadius * 2
+            ))
+            context.fill(headPath, with: .color(Color.mmTextSecondary.opacity(0.2)))
+
+            // 肩
+            let shoulderPath = RoundedRectPath(rect: shoulderRect, cornerRadius: 3)
+            context.fill(shoulderPath, with: .color(zoneColor(.shoulders)))
+
+            // 腕
+            let leftArmPath = RoundedRectPath(rect: leftArmRect, cornerRadius: 2)
+            let rightArmPath = RoundedRectPath(rect: rightArmRect, cornerRadius: 2)
+            context.fill(leftArmPath, with: .color(zoneColor(.arms)))
+            context.fill(rightArmPath, with: .color(zoneColor(.arms)))
+
+            // 胴体中央（前面=chest, 背面=back）
+            let torsoPath = RoundedRectPath(rect: torsoRect, cornerRadius: 3)
+            context.fill(torsoPath, with: .color(torsoColor))
+
+            // 体幹
+            let corePath = RoundedRectPath(rect: coreRect, cornerRadius: 2)
+            context.fill(corePath, with: .color(zoneColor(.core)))
+
+            // 脚
+            let leftLegPath = RoundedRectPath(rect: leftLegRect, cornerRadius: 3)
+            let rightLegPath = RoundedRectPath(rect: rightLegRect, cornerRadius: 3)
+            context.fill(leftLegPath, with: .color(zoneColor(.lowerBody)))
+            context.fill(rightLegPath, with: .color(zoneColor(.lowerBody)))
+        }
+        .frame(width: 14, height: 24)
+    }
+}
+
+// MARK: - 角丸矩形パス生成ヘルパー
+
+private func RoundedRectPath(rect: CGRect, cornerRadius: CGFloat) -> Path {
+    Path(roundedRect: rect, cornerRadius: cornerRadius)
+}
+
+// MARK: - 筋肉グループ色
+
+private func muscleGroupColor(_ group: MuscleGroup) -> Color {
+    switch group {
+    case .chest: return .mmMuscleJustWorked      // 赤系
+    case .back: return .mmAccentSecondary        // 青系
+    case .shoulders: return .mmMuscleAmber       // 黄系
+    case .arms: return .mmMuscleCoral            // オレンジ系
+    case .core: return .mmMuscleLime             // 黄緑系
+    case .lowerBody: return .mmAccentPrimary     // 緑系
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ZStack {
+        Color.mmBgPrimary.ignoresSafeArea()
+
+        VStack(spacing: 24) {
+            // 胸トレの日
+            HStack(spacing: 16) {
+                MicroBodyMapView(muscleGroups: [.chest, .arms, .shoulders])
+                Text("胸トレ → 前面の胸・肩・腕が光る")
+                    .font(.caption)
+                    .foregroundStyle(Color.mmTextSecondary)
+            }
+
+            // 背中トレの日
+            HStack(spacing: 16) {
+                MicroBodyMapView(muscleGroups: [.back, .arms])
+                Text("背中トレ → 背面の背中・腕が光る")
+                    .font(.caption)
+                    .foregroundStyle(Color.mmTextSecondary)
+            }
+
+            // 脚トレの日
+            HStack(spacing: 16) {
+                MicroBodyMapView(muscleGroups: [.lowerBody, .core])
+                Text("脚トレ → 脚・体幹が光る")
+                    .font(.caption)
+                    .foregroundStyle(Color.mmTextSecondary)
+            }
+
+            // フル（全部位）
+            HStack(spacing: 16) {
+                MicroBodyMapView(muscleGroups: [.chest, .back, .shoulders, .arms, .core, .lowerBody])
+                Text("全部位 → 全部光る")
+                    .font(.caption)
+                    .foregroundStyle(Color.mmTextSecondary)
+            }
+
+            // 空（休息日）
+            HStack(spacing: 16) {
+                MicroBodyMapView(muscleGroups: [])
+                Text("休息日 → 全部グレー")
+                    .font(.caption)
+                    .foregroundStyle(Color.mmTextSecondary)
+            }
+
+            // カレンダーセルサイズのデモ
+            Text("↓ カレンダーセルサイズでの見え方")
+                .font(.caption.bold())
+                .foregroundStyle(Color.mmTextPrimary)
+                .padding(.top, 16)
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 7), spacing: 8) {
+                ForEach(0..<7, id: \.self) { i in
+                    VStack(spacing: 2) {
+                        Text("\(i + 1)")
+                            .font(.subheadline)
+                            .foregroundStyle(Color.mmTextPrimary)
+
+                        if i == 0 || i == 3 || i == 5 {
+                            MicroBodyMapView(muscleGroups: i == 0 ? [.chest, .arms] : i == 3 ? [.back, .shoulders] : [.lowerBody])
+                        } else {
+                            Color.clear.frame(height: 24)
+                        }
+                    }
+                    .frame(height: 58)
+                    .background(Color.mmBgCard)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            .padding(.horizontal)
+        }
+        .padding()
+    }
+}

--- a/MuscleMap/Views/Components/MiniMuscleMapView.swift
+++ b/MuscleMap/Views/Components/MiniMuscleMapView.swift
@@ -14,7 +14,6 @@ struct MiniMuscleMapView: View {
         if let showFront = showFront {
             return showFront
         }
-        // 筋肉マッピングから自動判定
         let frontMuscles = Set(MusclePathData.frontMuscles.map { $0.muscle.rawValue.toSnakeCase() })
         let backMuscles = Set(MusclePathData.backMuscles.map { $0.muscle.rawValue.toSnakeCase() })
 
@@ -38,7 +37,6 @@ struct MiniMuscleMapView: View {
             let rect = CGRect(origin: .zero, size: geo.size)
 
             ZStack {
-                // 全ての筋肉を表示（刺激されない筋肉も薄く表示）
                 let muscles = shouldShowFront
                     ? MusclePathData.frontMuscles
                     : MusclePathData.backMuscles
@@ -49,11 +47,11 @@ struct MiniMuscleMapView: View {
 
                     path
                         .fill(colorFor(stimulation: stimulation))
-                    // 境界線（筋肉の形がわかるように）
                     path
                         .stroke(Color.mmMuscleBorder.opacity(0.3), lineWidth: 0.5)
                 }
             }
+            .drawingGroup()
         }
         .aspectRatio(0.6, contentMode: .fit)
     }
@@ -75,11 +73,9 @@ struct MiniMuscleMapView: View {
 
     private func colorFor(stimulation: Int) -> Color {
         guard stimulation > 0 else {
-            // 刺激されない筋肉 = 暗いグレー（でも形は見える）
             return Color.mmTextSecondary.opacity(0.15)
         }
 
-        // 刺激される筋肉 = 緑系でハイライト
         let opacity = max(0.4, Double(stimulation) / 100.0)
         return Color.mmAccentPrimary.opacity(opacity)
     }
@@ -107,11 +103,11 @@ private extension String {
 // MARK: - 種目適合性バッジ
 
 enum ExerciseCompatibility {
-    case recommended       // 全ての対象筋肉が回復済み
-    case partiallyRecovering  // 一部回復中
-    case recovering        // 主要筋肉が回復中
-    case restSuggested     // 高負荷の筋肉あり（休息推奨）
-    case neutral           // データなし
+    case recommended
+    case partiallyRecovering
+    case recovering
+    case restSuggested
+    case neutral
 
     @MainActor
     var badge: (text: String, color: Color)? {
@@ -134,13 +130,11 @@ enum ExerciseCompatibility {
 
 struct ExerciseCompatibilityCalculator {
 
-    /// 種目の適合性を計算
     static func calculate(
         exercise: ExerciseDefinition,
         muscleStates: [Muscle: MuscleStimulation]
     ) -> ExerciseCompatibility {
         let targetMuscles = exercise.muscleMapping.keys.compactMap { muscleId -> Muscle? in
-            // snake_case → Muscle enum
             for muscle in Muscle.allCases {
                 if muscle.rawValue == muscleId || muscle.rawValue.toSnakeCase() == muscleId {
                     return muscle
@@ -173,29 +167,24 @@ struct ExerciseCompatibilityCalculator {
                     recoveringCount += 1
                 }
             } else {
-                // 刺激記録なし → 回復済みとみなす
                 fullyRecoveredCount += 1
             }
         }
 
         let total = targetMuscles.count
 
-        // 高負荷の筋肉がある場合は休息推奨
         if highLoadCount > 0 {
             return .restSuggested
         }
 
-        // 全て回復済み
         if fullyRecoveredCount == total {
             return .recommended
         }
 
-        // 一部回復中
         if recoveringCount > 0 && fullyRecoveredCount > 0 {
             return .partiallyRecovering
         }
 
-        // 主に回復中
         if recoveringCount > 0 {
             return .recovering
         }
@@ -211,7 +200,6 @@ struct ExerciseCompatibilityCalculator {
         Color.mmBgPrimary.ignoresSafeArea()
 
         HStack(spacing: 20) {
-            // ベンチプレス（胸メイン）
             VStack {
                 MiniMuscleMapView(muscleMapping: [
                     "chest_upper": 65,
@@ -226,7 +214,6 @@ struct ExerciseCompatibilityCalculator {
                     .foregroundStyle(Color.mmTextSecondary)
             }
 
-            // デッドリフト（背中メイン）
             VStack {
                 MiniMuscleMapView(muscleMapping: [
                     "lats": 80,

--- a/MuscleMap/Views/Exercise/ExerciseDetailView.swift
+++ b/MuscleMap/Views/Exercise/ExerciseDetailView.swift
@@ -45,7 +45,7 @@ struct ExerciseDetailView: View {
                                 .foregroundStyle(Color.mmTextPrimary)
 
                             ExerciseMuscleMapView(muscleMapping: exercise.muscleMapping)
-                                .frame(height: 240)
+                                .padding(.vertical, 8)
                                 .background(Color.mmBgCard)
                                 .clipShape(RoundedRectangle(cornerRadius: 12))
 

--- a/MuscleMap/Views/Exercise/ExerciseLibraryView.swift
+++ b/MuscleMap/Views/Exercise/ExerciseLibraryView.swift
@@ -219,15 +219,13 @@ private struct ExerciseLibraryRow: View {
     let exercise: ExerciseDefinition
     private var localization: LocalizationManager { LocalizationManager.shared }
 
-    /// 主要ターゲット筋肉（刺激度が最も高い筋肉）
-    private var primaryTarget: (muscle: Muscle, percentage: Int)? {
-        guard let maxEntry = exercise.muscleMapping.max(by: { $0.value < $1.value }) else {
+    /// 主要ターゲットの筋肉グループ（刺激度が最も高い筋肉のグループ）
+    private var primaryMuscleGroup: MuscleGroup? {
+        guard let maxEntry = exercise.muscleMapping.max(by: { $0.value < $1.value }),
+              let muscle = Muscle(rawValue: maxEntry.key) ?? Muscle(snakeCase: maxEntry.key) else {
             return nil
         }
-        if let muscle = Muscle(rawValue: maxEntry.key) ?? Muscle(snakeCase: maxEntry.key) {
-            return (muscle, maxEntry.value)
-        }
-        return nil
+        return muscle.group
     }
 
     var body: some View {
@@ -237,7 +235,7 @@ private struct ExerciseLibraryRow: View {
                 ExerciseGifView(exerciseId: exercise.id, size: .thumbnail)
             } else {
                 MiniMuscleMapView(muscleMapping: exercise.muscleMapping)
-                    .frame(width: 80, height: 60)
+                    .frame(width: 100, height: 75)
                     .background(Color.mmBgPrimary.opacity(0.5))
                     .clipShape(RoundedRectangle(cornerRadius: 8))
             }
@@ -250,23 +248,10 @@ private struct ExerciseLibraryRow: View {
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
 
-                // 日本語モード時のみ英語名サブタイトルを表示
-                if localization.currentLanguage == .japanese {
-                    Text(exercise.nameEN)
-                        .font(.caption)
-                        .foregroundStyle(Color.mmTextSecondary)
-                        .lineLimit(1)
-                }
-
-                // 主要ターゲット筋肉 + 器具と難易度のタグ
+                // 筋肉グループ + 器具タグ
                 HStack(spacing: 6) {
-                    if let target = primaryTarget {
-                        PrimaryTargetTag(
-                            muscleName: localization.currentLanguage == .japanese
-                                ? target.muscle.japaneseName
-                                : target.muscle.englishName,
-                            percentage: target.percentage
-                        )
+                    if let group = primaryMuscleGroup {
+                        MuscleGroupTag(groupName: group.localizedName)
                     }
                     ExerciseTag(text: exercise.localizedEquipment, icon: "dumbbell")
                 }
@@ -282,18 +267,17 @@ private struct ExerciseLibraryRow: View {
     }
 }
 
-// MARK: - 主要ターゲット筋肉タグ
+// MARK: - 筋肉グループタグ
 
-private struct PrimaryTargetTag: View {
-    let muscleName: String
-    let percentage: Int
+private struct MuscleGroupTag: View {
+    let groupName: String
 
     var body: some View {
         HStack(spacing: 3) {
             Circle()
                 .fill(Color.mmAccentPrimary)
                 .frame(width: 6, height: 6)
-            Text("\(muscleName) \(percentage)%")
+            Text(groupName)
                 .lineLimit(1)
         }
         .font(.caption2.bold())

--- a/MuscleMap/Views/Exercise/ExerciseLibraryView.swift
+++ b/MuscleMap/Views/Exercise/ExerciseLibraryView.swift
@@ -219,13 +219,12 @@ private struct ExerciseLibraryRow: View {
     let exercise: ExerciseDefinition
     private var localization: LocalizationManager { LocalizationManager.shared }
 
-    /// 主要ターゲットの筋肉グループ（刺激度が最も高い筋肉のグループ）
-    private var primaryMuscleGroup: MuscleGroup? {
-        guard let maxEntry = exercise.muscleMapping.max(by: { $0.value < $1.value }),
-              let muscle = Muscle(rawValue: maxEntry.key) ?? Muscle(snakeCase: maxEntry.key) else {
+    /// 主要ターゲットの筋肉（刺激度が最も高い筋肉）
+    private var primaryMuscle: Muscle? {
+        guard let maxEntry = exercise.muscleMapping.max(by: { $0.value < $1.value }) else {
             return nil
         }
-        return muscle.group
+        return Muscle(rawValue: maxEntry.key) ?? Muscle(snakeCase: maxEntry.key)
     }
 
     var body: some View {
@@ -248,10 +247,14 @@ private struct ExerciseLibraryRow: View {
                     .lineLimit(2)
                     .fixedSize(horizontal: false, vertical: true)
 
-                // 筋肉グループ + 器具タグ
+                // 筋肉名 + 器具タグ
                 HStack(spacing: 6) {
-                    if let group = primaryMuscleGroup {
-                        MuscleGroupTag(groupName: group.localizedName)
+                    if let muscle = primaryMuscle {
+                        PrimaryMuscleTag(
+                            muscleName: localization.currentLanguage == .japanese
+                                ? muscle.japaneseName
+                                : muscle.englishName
+                        )
                     }
                     ExerciseTag(text: exercise.localizedEquipment, icon: "dumbbell")
                 }
@@ -267,17 +270,17 @@ private struct ExerciseLibraryRow: View {
     }
 }
 
-// MARK: - 筋肉グループタグ
+// MARK: - 主要筋肉タグ
 
-private struct MuscleGroupTag: View {
-    let groupName: String
+private struct PrimaryMuscleTag: View {
+    let muscleName: String
 
     var body: some View {
         HStack(spacing: 3) {
             Circle()
                 .fill(Color.mmAccentPrimary)
                 .frame(width: 6, height: 6)
-            Text(groupName)
+            Text(muscleName)
                 .lineLimit(1)
         }
         .font(.caption2.bold())

--- a/MuscleMap/Views/Exercise/ExerciseMuscleMapView.swift
+++ b/MuscleMap/Views/Exercise/ExerciseMuscleMapView.swift
@@ -46,17 +46,15 @@ struct ExerciseMuscleMapView: View {
             // 凡例
             legendView
         }
+        .padding(.vertical, 8)
     }
     
     // MARK: - 刺激度の取得
     
     private func stimulationFor(_ muscle: Muscle) -> Int {
-        // muscle.rawValue は "chestUpper" 形式
-        // muscleMapping のキーは "chest_upper" 形式の可能性があるので両方チェック
         if let value = muscleMapping[muscle.rawValue] {
             return value
         }
-        // スネークケースに変換してチェック
         let snakeCase = muscle.rawValue.toSnakeCase()
         if let value = muscleMapping[snakeCase] {
             return value
@@ -68,12 +66,9 @@ struct ExerciseMuscleMapView: View {
 
     private func colorFor(stimulation: Int) -> Color {
         guard stimulation > 0 else {
-            // 刺激されない筋肉 = 暗いグレー（シルエットが見える程度）
             return Color.mmTextSecondary.opacity(0.2)
         }
 
-        // 刺激度に応じてグラデーション
-        // 低 → 黄緑、中 → 黄、高 → オレンジ/赤
         let opacity = 0.4 + (Double(stimulation) / 100.0) * 0.6
 
         switch stimulation {
@@ -125,6 +120,7 @@ private struct SingleBodyMapView: View {
                         .stroke(Color.mmMuscleBorder.opacity(0.4), lineWidth: 0.8)
                 }
             }
+            .drawingGroup()
         }
         .aspectRatio(0.6, contentMode: .fit)
     }

--- a/MuscleMap/Views/History/HistoryMapComponents.swift
+++ b/MuscleMap/Views/History/HistoryMapComponents.swift
@@ -20,9 +20,8 @@ struct HistoryMapView: View {
 
             // 筋肉マップカード
             VStack(spacing: 16) {
-                // 前面/背面トグル（改善版）
+                // 前面/背面トグル
                 HStack {
-                    // 現在の表示面
                     HStack(spacing: 6) {
                         Image(systemName: showFront ? "person.fill" : "person.fill")
                             .font(.caption)
@@ -33,7 +32,6 @@ struct HistoryMapView: View {
 
                     Spacer()
 
-                    // トグルボタン
                     Button {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             showFront.toggle()
@@ -54,7 +52,7 @@ struct HistoryMapView: View {
                     }
                 }
 
-                // 筋肉マップ（ホーム画面と同じ表示品質を維持）
+                // 筋肉マップ
                 HistoryMuscleMapCanvas(
                     muscleSets: viewModel.periodMuscleSets,
                     showFront: showFront,
@@ -77,7 +75,7 @@ struct HistoryMapView: View {
     }
 }
 
-// MARK: - 期間セレクター（改善版）
+// MARK: - 期間セレクター
 
 struct PeriodSelector: View {
     let selectedPeriod: HistoryPeriod
@@ -155,6 +153,7 @@ struct HistoryMuscleMapCanvas: View {
                     }
                 }
             }
+            .drawingGroup()
         }
         .aspectRatio(0.6, contentMode: .fit)
     }
@@ -166,7 +165,6 @@ struct HistoryMuscleMapCanvas: View {
 
         let ratio = Double(sets) / Double(maxSets)
 
-        // セット数に応じたグラデーション
         if ratio < 0.25 {
             return Color.mmMuscleLime.opacity(0.4)
         } else if ratio < 0.5 {
@@ -213,7 +211,7 @@ struct HistoryMusclePathView: View {
 }
 
 
-// MARK: - 履歴マップ凡例（改善版）
+// MARK: - 履歴マップ凡例
 
 struct HistoryMapLegend: View {
     private var localization: LocalizationManager { LocalizationManager.shared }

--- a/MuscleMap/Views/History/MonthlyCalendarView.swift
+++ b/MuscleMap/Views/History/MonthlyCalendarView.swift
@@ -247,9 +247,6 @@ private struct DayCell: View {
 
     private let calendar = Calendar.current
 
-    // 筋肉グループの表示順
-    private static let groupOrder: [MuscleGroup] = [.chest, .back, .shoulders, .arms, .core, .lowerBody]
-
     var body: some View {
         Button(action: action) {
             VStack(spacing: 2) {
@@ -258,9 +255,9 @@ private struct DayCell: View {
                     .fontWeight(isToday ? .bold : .regular)
                     .foregroundStyle(textColor)
 
-                // パターン3: マイクロマップ（簡略化シルエット）
+                // マイクロボディマップ（前面+背面の2体表示）
                 if hasWorkout && !muscleGroups.isEmpty {
-                    MicroMuscleIcon(muscleGroups: muscleGroups)
+                    MicroBodyMapView(muscleGroups: muscleGroups)
                 } else if hasWorkout {
                     // 筋肉グループ情報がない場合は従来の緑ドット
                     Circle()
@@ -268,7 +265,7 @@ private struct DayCell: View {
                         .frame(width: 6, height: 6)
                 } else {
                     Color.clear
-                        .frame(height: 10)
+                        .frame(height: 24)
                 }
             }
             .frame(maxWidth: .infinity)
@@ -276,37 +273,6 @@ private struct DayCell: View {
             .background(backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: 8))
         }
-    }
-
-    // パターン1: ドットグリッド（最大4つ）
-    private var muscleGroupDots: some View {
-        let sortedGroups = Self.groupOrder.filter { muscleGroups.contains($0) }
-
-        return HStack(spacing: 2) {
-            ForEach(sortedGroups.prefix(4), id: \.self) { group in
-                Circle()
-                    .fill(muscleGroupColor(group))
-                    .frame(width: 5, height: 5)
-            }
-        }
-        .frame(height: 10)
-    }
-
-    // パターン2: カラーバー（セグメント分割）
-    private var muscleGroupBar: some View {
-        let sortedGroups = Self.groupOrder.filter { muscleGroups.contains($0) }
-
-        return GeometryReader { geo in
-            HStack(spacing: 1) {
-                ForEach(sortedGroups, id: \.self) { group in
-                    RoundedRectangle(cornerRadius: 2)
-                        .fill(muscleGroupColor(group))
-                }
-            }
-        }
-        .frame(height: 6)
-        .clipShape(RoundedRectangle(cornerRadius: 3))
-        .padding(.horizontal, 4)
     }
 
     private var textColor: Color {
@@ -327,28 +293,6 @@ private struct DayCell: View {
         } else {
             return Color.clear
         }
-    }
-}
-
-// MARK: - マイクロ筋肉アイコン（カレンダー用 - カラードットグリッド）
-
-private struct MicroMuscleIcon: View {
-    let muscleGroups: Set<MuscleGroup>
-
-    // 表示順（重要度順）
-    private static let groupOrder: [MuscleGroup] = [.chest, .back, .shoulders, .arms, .core, .lowerBody]
-
-    var body: some View {
-        let activeGroups = Self.groupOrder.filter { muscleGroups.contains($0) }
-
-        HStack(spacing: 2) {
-            ForEach(activeGroups.prefix(4), id: \.self) { group in
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(muscleGroupColor(group))
-                    .frame(width: 6, height: 6)
-            }
-        }
-        .frame(height: 10)
     }
 }
 

--- a/MuscleMap/Views/MuscleDetail/Muscle3DView.swift
+++ b/MuscleMap/Views/MuscleDetail/Muscle3DView.swift
@@ -114,6 +114,8 @@ struct Muscle3DView: View {
                         }
                     }
                 }
+                // drawingGroup でMetal描画 → アンチエイリアスが効く
+                .drawingGroup()
                 .scaleEffect(scale, anchor: .topLeading)
                 .offset(x: offsetX, y: offsetY)
             }

--- a/MuscleMap/Views/Workout/ExercisePreviewSheet.swift
+++ b/MuscleMap/Views/Workout/ExercisePreviewSheet.swift
@@ -40,19 +40,11 @@ struct ExercisePreviewSheet: View {
 
                 ScrollView {
                     VStack(spacing: 20) {
-                        // 種目名
                         exerciseNameSection
-
-                        // ミニ筋肉マップ
                         muscleMapSection
-
-                        // 対象筋肉リスト
                         targetMusclesSection
-
-                        // YouTubeボタン
                         youtubeButtonSection
 
-                        // この種目を追加ボタン（ワークアウトフローからの場合のみ）
                         if onAddExercise != nil {
                             addExerciseButton
                         }
@@ -91,7 +83,6 @@ struct ExercisePreviewSheet: View {
                 .font(.subheadline)
                 .foregroundStyle(Color.mmTextSecondary)
 
-            // 基本情報タグ（器具のみ、難易度は詳細画面で確認）
             HStack(spacing: 8) {
                 InfoChip(icon: "dumbbell", text: exercise.localizedEquipment)
             }
@@ -103,7 +94,6 @@ struct ExercisePreviewSheet: View {
 
     private var muscleMapSection: some View {
         VStack(spacing: 8) {
-            // ラベル
             HStack {
                 Text(L10n.targetMuscles)
                     .font(.caption.bold())
@@ -111,7 +101,6 @@ struct ExercisePreviewSheet: View {
                 Spacer()
             }
 
-            // GIF + ミニマップ横並び（GIFがある場合）
             if ExerciseGifView.hasGif(exerciseId: exercise.id) {
                 HStack(spacing: 10) {
                     ExerciseGifView(exerciseId: exercise.id, size: .previewCard)
@@ -125,7 +114,6 @@ struct ExercisePreviewSheet: View {
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
             } else {
-                // GIFがない場合は従来通りMuscleMap単体
                 PreviewMuscleMapView(
                     muscleMapping: exercise.muscleMapping,
                     primaryThreshold: 60
@@ -135,7 +123,6 @@ struct ExercisePreviewSheet: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
 
-            // 凡例
             HStack(spacing: 16) {
                 HStack(spacing: 4) {
                     Circle()
@@ -161,7 +148,6 @@ struct ExercisePreviewSheet: View {
 
     private var targetMusclesSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Primary（最大3つまで表示）
             if !primaryMuscles.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(L10n.primaryTarget)
@@ -187,7 +173,6 @@ struct ExercisePreviewSheet: View {
                 }
             }
 
-            // Secondary（最大3つまで表示）
             if !secondaryMuscles.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(L10n.secondaryTarget)
@@ -317,6 +302,7 @@ private struct PreviewMuscleMapView: View {
                         .stroke(Color.mmMuscleBorder.opacity(0.3), lineWidth: 0.5)
                 }
             }
+            .drawingGroup()
         }
         .aspectRatio(0.6, contentMode: .fit)
     }
@@ -337,7 +323,6 @@ private struct PreviewMuscleMapView: View {
             return Color.mmTextSecondary.opacity(0.15)
         }
 
-        // Primary (60%+) = 赤系、Secondary (<60%) = オレンジ系
         if stimulation >= primaryThreshold {
             return Color.mmMuscleJustWorked.opacity(0.8)
         } else {

--- a/MuscleMap/Views/Workout/SetInputComponents.swift
+++ b/MuscleMap/Views/Workout/SetInputComponents.swift
@@ -157,9 +157,9 @@ struct SetInputCard: View {
             if !isBodyweight || useAdditionalWeight {
                 HStack(spacing: 16) {
                     WeightStepperButton(systemImage: "minus") {
-                        viewModel.adjustWeight(by: -0.25)  // タップ = 細かく
+                        viewModel.adjustWeight(by: -0.25)
                     } onLongPress: {
-                        viewModel.adjustWeight(by: -2.5)   // 長押し = 大きく
+                        viewModel.adjustWeight(by: -2.5)
                     }
 
                     WeightInputView(
@@ -169,9 +169,9 @@ struct SetInputCard: View {
                     .frame(minWidth: 100)
 
                     WeightStepperButton(systemImage: "plus") {
-                        viewModel.adjustWeight(by: 0.25)   // タップ = 細かく
+                        viewModel.adjustWeight(by: 0.25)
                     } onLongPress: {
-                        viewModel.adjustWeight(by: 2.5)    // 長押し = 大きく
+                        viewModel.adjustWeight(by: 2.5)
                     }
                 }
             }
@@ -205,7 +205,6 @@ struct SetInputCard: View {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
                         showPRCelebration = true
                     }
-                    // 2秒後に自動で閉じる
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                         withAnimation(.easeOut(duration: 0.3)) {
                             showPRCelebration = false
@@ -230,7 +229,6 @@ struct SetInputCard: View {
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .padding(.horizontal)
         .overlay {
-            // PR達成祝福オーバーレイ
             if showPRCelebration {
                 PRCelebrationOverlay()
                     .transition(.scale.combined(with: .opacity))
@@ -241,31 +239,28 @@ struct SetInputCard: View {
 
 // MARK: - PR達成祝福オーバーレイ
 
-/// PR達成時の祝福オーバーレイ
 struct PRCelebrationOverlay: View {
     @State private var scale: CGFloat = 0.5
     @State private var rotation: Double = -10
     @State private var opacity: Double = 0
+    private var localization: LocalizationManager { LocalizationManager.shared }
 
     var body: some View {
         ZStack {
-            // 背景のぼかし
             Color.black.opacity(0.6)
                 .ignoresSafeArea()
 
             VStack(spacing: 16) {
-                // トロフィーアイコン
                 Image(systemName: "trophy.fill")
                     .font(.system(size: 60))
                     .foregroundStyle(.yellow)
                     .shadow(color: .yellow.opacity(0.5), radius: 10)
 
-                // PRテキスト
                 Text("🎉 NEW PR! 🎉")
                     .font(.title.bold())
                     .foregroundStyle(.white)
 
-                Text("自己ベスト更新！")
+                Text(localization.currentLanguage == .japanese ? "自己ベスト更新！" : "Personal Record!")
                     .font(.headline)
                     .foregroundStyle(Color.mmAccentPrimary)
             }
@@ -284,10 +279,6 @@ struct PRCelebrationOverlay: View {
 }
 
 // MARK: - Preview
-
-//#Preview {
-//    // Preview requires full app context with Swift Data
-//}
 
 #Preview("PR Celebration") {
     ZStack {

--- a/MuscleMap/Views/Workout/WorkoutCompletionSections.swift
+++ b/MuscleMap/Views/Workout/WorkoutCompletionSections.swift
@@ -65,7 +65,7 @@ struct StimulatedMusclesSection: View {
                     muscleMapping: muscleMapping,
                     showFront: true
                 )
-                .aspectRatio(0.5, contentMode: .fit)
+                .aspectRatio(0.6, contentMode: .fit)
                 .frame(maxWidth: .infinity)
                 .frame(height: 220)
 
@@ -74,7 +74,7 @@ struct StimulatedMusclesSection: View {
                     muscleMapping: muscleMapping,
                     showFront: false
                 )
-                .aspectRatio(0.5, contentMode: .fit)
+                .aspectRatio(0.6, contentMode: .fit)
                 .frame(maxWidth: .infinity)
                 .frame(height: 220)
             }

--- a/MuscleMap/Views/Workout/WorkoutCompletionView.swift
+++ b/MuscleMap/Views/Workout/WorkoutCompletionView.swift
@@ -75,13 +75,26 @@ struct WorkoutCompletionView: View {
         exercisesDone.map { localization.currentLanguage == .japanese ? $0.nameJA : $0.nameEN }
     }
 
+    private func formatVolume(_ volume: Double) -> String {
+        volume >= 1000 ? String(format: "%.1fk", volume / 1000) : String(format: "%.0f", volume)
+    }
+
     private var shareText: String {
-        """
-        今日のワークアウト完了 💪
-        \(uniqueExercises)種目 | \(totalSets)セット | \(formatVolume(totalVolume))kg
-        \(AppConstants.shareHashtag)
-        \(AppConstants.appStoreURL)
-        """
+        if localization.currentLanguage == .japanese {
+            return """
+            今日のワークアウト完了 💪
+            \(uniqueExercises)種目 | \(totalSets)セット | \(formatVolume(totalVolume))kg
+            \(AppConstants.shareHashtag)
+            \(AppConstants.appStoreURL)
+            """
+        } else {
+            return """
+            Workout Complete 💪
+            \(uniqueExercises) exercises | \(totalSets) sets | \(formatVolume(totalVolume))kg
+            \(AppConstants.shareHashtag)
+            \(AppConstants.appStoreURL)
+            """
+        }
     }
 
     var body: some View {
@@ -241,10 +254,6 @@ struct WorkoutCompletionView: View {
         UIApplication.shared.open(url) { success in
             if success { HapticManager.success() }
         }
-    }
-
-    private func formatVolume(_ volume: Double) -> String {
-        volume >= 1000 ? String(format: "%.1fk", volume / 1000) : String(format: "%.0f", volume)
     }
 }
 


### PR DESCRIPTION
## 変更内容

Exercise Library のリスト行をスッキリ改善。

### Before
```
[GIF 80x60] | Barbell Bench Press
            | バーベルベンチプレス  
            | ● Lower Chest 100%  ⊘ Barbell
```

### After
```
[GIF 100x75] | Barbell Bench Press
             | ● 胸  ⊘ Barbell
```

### 詳細
- **GIFサムネイル**: 80x60 → 100x75 に拡大（動きが見やすく）
- **筋肉タグ**: `Lower Chest 100%` → 筋肉グループ名のみ（`胸` / `Chest`）
  - パーセンテージ削除（全部100%で情報価値なかった）
  - 個別筋肉名 → グループ名（一覧で把握しやすく）
  - `MuscleGroup.localizedName` を使用（多言語対応済み）
- **英語サブタイトル行**: 削除（情報過多の解消）

### 変更ファイル
- `ExerciseGifView.swift` — thumbnail サイズ変更
- `ExerciseLibraryView.swift` — 行レイアウト・タグ簡素化